### PR TITLE
Fix SSR problem

### DIFF
--- a/CSBS-Dashboard/vite.config.ts
+++ b/CSBS-Dashboard/vite.config.ts
@@ -4,5 +4,17 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  plugins: [tailwindcss(), reactRouter(), tsconfigPaths(), {
+    name: 'ignore-css-during-ssr',
+    enforce: 'pre',
+    resolveId(id) {
+      if (id.endsWith('.css')) return id;
+    },
+    load(id) {
+      if (id.endsWith('.css')) return '';
+    },
+  },],
+  ssr: {
+    noExternal: ["@mui/x-data-grid"], // Ensure MUI Data Grid is processed in SSR
+  },
 });


### PR DESCRIPTION
SSR doesn't account for .css files so i added some new configurations to vite.config.ts that ignore the .css files and make sure MuiDataGrid (The place that was requesting css files) is rendered properly 